### PR TITLE
Keep empty text params

### DIFF
--- a/lib/Parser/prototype.onTextParam.js
+++ b/lib/Parser/prototype.onTextParam.js
@@ -24,10 +24,6 @@ module.exports = function onTextParam(part) {
   // Track fields that receive multiple param values
   self.multifields = self.multifields || {};
 
-  // Track if at least one chunk was received
-  // (used for determining whether to set the parameter at all)
-  var receivedAtLeastOneChunk = false;
-
   // After control has been relinquished, any textparams received should be ignored
   // since its too late to include them in `req.body` (subsequent app code is already running)
   // So emit a warning.
@@ -60,10 +56,6 @@ module.exports = function onTextParam(part) {
 
     // New bytes available for text param:
     if (buffer) {
-
-      // Track if at least one chunk was received
-      // (used for determining whether to set the parameter at all)
-      receivedAtLeastOneChunk = true;
 
       // TODO: make `maxFieldsSize` directly configurable via `options`
       self.form._fieldsSize += buffer.length;
@@ -102,7 +94,7 @@ module.exports = function onTextParam(part) {
         self.multifields[field] = true;
         self.req.body[field].push(value);
       }
-    } else if (receivedAtLeastOneChunk) {
+    } else {
       self.req.body[field] = value;
     }
 

--- a/test/req.body.test.js
+++ b/test/req.body.test.js
@@ -54,6 +54,7 @@ describe('req.body ::', function() {
 		var pathToSmallFile = smallFile.path;
 		form.append('foo', 'hello');
 		form.append('bar', 'there');
+		form.append('emptyParam', '');
 		form.append('avatar', fsx.createReadStream(pathToSmallFile));
 
 	});
@@ -62,6 +63,7 @@ describe('req.body ::', function() {
 		assert(bodyParamsThatWereAccessible);
 		assert(bodyParamsThatWereAccessible.foo);
 		assert(bodyParamsThatWereAccessible.bar);
+		assert.strictEqual(bodyParamsThatWereAccessible.emptyParam, '');
 	});
 
 


### PR DESCRIPTION
Skipper discards empty text params while it must keep tha params with their value being the empty string.

Sending a form with some empty inputs using `multipart/form-data` or using the FormData Web API Interface (XMLHttpRequest Level 2) will send the empty params just the way you have `param1` and `param2` available as part of your request on the server side when you request a `?param1=&param2` url.
Skipper shouldn't get rid of those as those are needed when part of a PUT/update request. Currently those model attributes (database fields) remain unchanged instead of overwritten with an empty string.