### PR TITLE
Do not process.exit() from a module

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var connect = require('connect');
 if (!require('semver').satisfies(process.version, '>=0.10.0')) {
   console.error('`skipper` (bodyParser) requires node version >= 0.10.0.');
   console.error('Please upgrade Node at http://nodejs.org/ or with `nvm`');
-  process.exit(1);
+  throw new Error('Invalid Node.js version');
 }
 
 //


### PR DESCRIPTION
Exiting the process from a module is generally [considered bad practice](http://eslint.org/docs/rules/no-process-exit.html) - the developer might want to handle these conditions differently (i.e. load another module if this one does not like the current runtime, send a warning email or slap the developer in the face, asynchronously).

Throw instead!