### PR TITLE
Added s3 header permissions information and example to the readme file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,10 @@ req.file('avatar').upload({
   adapter: require('skipper-s3'),
   key: 'YOUR_S3_API_KEY',
   secret: 'YOUR_S3_API_SECRET',
-  bucket: 'YOUR_S3_BUCKET'
+  bucket: 'YOUR_S3_BUCKET',
+  headers: {
+    'x-amz-acl': 'YOUR_FILE_PERMISSIONS'
+  }
 }, ...);
 ```
 
@@ -112,7 +115,8 @@ It exposes the following adapter-specific options:
  endpoint   | ((string))                       | By default all requests will be sent to the global endpoint `s3.amazonaws.com`. But if you want to manually set the endpoint, you can do it with the endpoint option. |
  region     | ((string))                       | The S3 region where the bucket is located, e.g. `"us-west-2"`. Note: If `endpoint` is defined, `region` will be ignored. Defaults to `"us-standard"` |
  tmpdir     | ((string))                       | The path to the directory where buffering multipart requests can rest their heads.  Amazon requires "parts" sent to their multipart upload API to be at least 5MB in size, so this directory is used to queue up chunks of data until a big enough payload has accumulated.  Defaults to `.tmp/s3-upload-part-queue` (resolved from the current working directory of the node process- e.g. your app)
- 
+ headers    | ((object))                       | A set of headers to be added to the upload request.  These can be used for setting permissions on the uploaded file.  See the [**Amazon AWS**](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUT.html) documentation for more information about specific permission headers.
+
 
 #### Uploading files to PostgreSQL
 


### PR DESCRIPTION
Had a bit of a hard time tracking down this information so I thought I'd add it to the documentation.