### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "dot-access": "1.0.0",
     "lodash": "3.10.1",
     "multiparty": "3.2.10",
-    "node-uuid": "1.4.7",
     "semver": "4.3.6",
     "skipper-disk": "~0.5.6",
-    "string_decoder": "0.10.31"
+    "string_decoder": "0.10.31",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "concat-stream": "1.5.2",

--- a/standalone/Upstream/build-renamer-stream.js
+++ b/standalone/Upstream/build-renamer-stream.js
@@ -5,7 +5,7 @@
 var path = require('path');
 var _ = require('lodash');
 var TransformStream = require('stream').Transform;
-var UUIDGenerator = require('node-uuid');
+var UUIDGenerator = require('uuid');
 
 
 /**

--- a/test/sucessive.file.upload.test.js
+++ b/test/sucessive.file.upload.test.js
@@ -11,7 +11,7 @@ var Lifecycle = require('./helpers/lifecycle')
   , toValidateTheHTTPResponse = require('./helpers/toValidateTheHTTPResponse')
   , fsx = require('fs-extra')
   , async = require('async')
-  , uuid = require('node-uuid');
+  , uuid = require('uuid');
 
 
 // Fixtures


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.